### PR TITLE
Added default guest filter for past events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ npm-debug.log
 yarn-error.log
 .env
 secrets.yml
+sitemap.xsd
+docker-compose.override.yml
 
 # Created by https://www.gitignore.io/api/macos
 

--- a/app/Http/Filters/OrganisationEvent/EndsAfterFilter.php
+++ b/app/Http/Filters/OrganisationEvent/EndsAfterFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Filters\OrganisationEvent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+class EndsAfterFilter implements Filter
+{
+    public function __invoke(Builder $query, $value, string $property): Builder
+    {
+        return $query->whereDate('end_date', '>=', $value);
+    }
+}

--- a/app/Http/Filters/OrganisationEvent/EndsBeforeFilter.php
+++ b/app/Http/Filters/OrganisationEvent/EndsBeforeFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Filters\OrganisationEvent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+class EndsBeforeFilter implements Filter
+{
+    public function __invoke(Builder $query, $value, string $property): Builder
+    {
+        return $query->whereDate('end_date', '<=', $value);
+    }
+}

--- a/app/Http/Filters/OrganisationEvent/StartsAfterFilter.php
+++ b/app/Http/Filters/OrganisationEvent/StartsAfterFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Filters\OrganisationEvent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+class StartsAfterFilter implements Filter
+{
+    public function __invoke(Builder $query, $value, string $property): Builder
+    {
+        return $query->whereDate('start_date', '>=', $value);
+    }
+}

--- a/app/Http/Filters/OrganisationEvent/StartsBeforeFilter.php
+++ b/app/Http/Filters/OrganisationEvent/StartsBeforeFilter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Filters\OrganisationEvent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+class StartsBeforeFilter implements Filter
+{
+    public function __invoke(Builder $query, $value, string $property): Builder
+    {
+        return $query->whereDate('start_date', '<=', $value);
+    }
+}


### PR DESCRIPTION
### Summary

https://app.shortcut.com/ayup-digital-ltd/story/1953/events-with-dates-past-today-to-be-auto-disabled-must

- Added date filters for start_date and end_date
- Applied filter for end_date after if user is guest but not if logged in

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
