### PR TITLE
Hounslow sc 1946 event filtering post code should

### DIFF
--- a/app/Search/ElasticsearchEventSearch.php
+++ b/app/Search/ElasticsearchEventSearch.php
@@ -74,6 +74,7 @@ class ElasticsearchEventSearch implements EventSearch
         $should = &$this->query['query']['bool']['must']['bool']['should'];
 
         $should[] = $this->match('title', $term, 3);
+        $should[] = $this->match('organisation_name', $term, 3);
         $should[] = $this->match('intro', $term, 2);
         $should[] = $this->match('description', $term, 1.5);
         $should[] = $this->match('taxonomy_categories', $term);
@@ -428,7 +429,7 @@ class ElasticsearchEventSearch implements EventSearch
         return $events->filter(function (OrganisationEvent $event) {
             return !$event->is_virtual;
         })
-            ->each(function (OrganisationEvent $event) {
+            ->sortBy(function (OrganisationEvent $event) {
                 $location = $this->query['sort'][0]['_geo_distance']['event_location.location'];
                 $location = new Coordinate($location['lat'], $location['lon']);
 

--- a/config/ck.php
+++ b/config/ck.php
@@ -62,7 +62,7 @@ return [
     /*
      * The distance (in miles) that the search results should limit up to.
      */
-    'search_distance' => 15,
+    'search_distance' => 5,
 
     /*
      * The dimensions to automatically generate resized images at.

--- a/tests/Feature/SearchEventTest.php
+++ b/tests/Feature/SearchEventTest.php
@@ -749,7 +749,7 @@ class SearchEventTest extends TestCase implements UsesElasticsearch
      */
     public function searchEventsFilterByDateRange()
     {
-        $date1 = $this->faker->dateTimeBetween('+3 days', '+1 weeks');
+        $date1 = $this->faker->dateTimeBetween('+4 days', '+1 weeks');
         $date2 = $this->faker->dateTimeBetween('+2 week', '+3 weeks');
         $date3 = $this->faker->dateTimeBetween('+1 days', '+2 days');
         $endtime = $this->faker->time('H:i:s', '+1 hour');
@@ -892,7 +892,7 @@ class SearchEventTest extends TestCase implements UsesElasticsearch
     /**
      * @test
      */
-    public function searchEventsOrderByRelevanceWithLocationReturnServicesLessThan5MilesAway()
+    public function searchEventsOrderByRelevanceWithLocationReturnEventsLessThan5MilesAway()
     {
         $event1 = factory(OrganisationEvent::class)->create([
             'is_virtual' => false,
@@ -905,11 +905,12 @@ class SearchEventTest extends TestCase implements UsesElasticsearch
         ]);
 
         $event2 = factory(OrganisationEvent::class)->create([
+            'title' => 'Test Name',
             'is_virtual' => false,
             'location_id' => function () {
                 return factory(Location::class)->create([
-                    'lat' => 45.01,
-                    'lon' => 90.01,
+                    'lat' => 45.001,
+                    'lon' => 90.001,
                 ])->id;
             },
         ]);

--- a/tests/Feature/SearchEventTest.php
+++ b/tests/Feature/SearchEventTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Collection;
 use App\Models\Location;
+use App\Models\Organisation;
 use App\Models\OrganisationEvent;
 use App\Models\Taxonomy;
 use Illuminate\Http\Response;
@@ -787,6 +788,320 @@ class SearchEventTest extends TestCase implements UsesElasticsearch
         $response->assertJsonFragment(['id' => $organisationEvent1->id]);
         $response->assertJsonMissing(['id' => $organisationEvent3->id]);
         $response->assertJsonMissing(['id' => $organisationEvent2->id]);
+    }
+
+    /**
+     * @test
+     */
+    public function searchEventsOrderByLocationReturnEventsLessThan5MilesAway()
+    {
+        $event1 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 0,
+                    'lon' => 0,
+                ])->id;
+            },
+        ]);
+
+        $event2 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 45,
+                    'lon' => 90,
+                ])->id;
+            },
+        ]);
+
+        $event3 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 90,
+                    'lon' => 180,
+                ])->id;
+            },
+        ]);
+
+        $response = $this->json('POST', '/core/v1/search/events', [
+            'order' => 'distance',
+            'location' => [
+                'lat' => 45,
+                'lon' => 90,
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment(['id' => $event2->id]);
+        $response->assertJsonMissing(['id' => $event1->id]);
+        $response->assertJsonMissing(['id' => $event3->id]);
+    }
+
+    /**
+     * @test
+     */
+    public function searchEventsOrderByLocationReturnServicesLessThan1MileAway()
+    {
+        // > 1 mile
+        $event1 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 51.469954129107016, 'lon' => -0.3973609967291171,
+                ])->id;
+            },
+        ]);
+
+        // < 1 mile
+        $event2 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 51.46813624630186, 'lon' => -0.38543053111827796,
+                ])->id;
+            },
+        ]);
+
+        // > 1 mile
+        $event3 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 51.47591520714541, 'lon' => -0.41139431461981674,
+                ])->id;
+            },
+        ]);
+
+        $response = $this->json('POST', '/core/v1/search/events', [
+            'order' => 'distance',
+            'distance' => 1,
+            'location' => [
+                'lat' => 51.46843366223185,
+                'lon' => -0.3674811879751439,
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment(['id' => $event2->id]);
+        $response->assertJsonMissing(['id' => $event1->id]);
+        $response->assertJsonMissing(['id' => $event3->id]);
+    }
+
+    /**
+     * @test
+     */
+    public function searchEventsOrderByRelevanceWithLocationReturnServicesLessThan5MilesAway()
+    {
+        $event1 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 0,
+                    'lon' => 0,
+                ])->id;
+            },
+        ]);
+
+        $event2 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 45.01,
+                    'lon' => 90.01,
+                ])->id;
+            },
+        ]);
+
+        $event3 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 45,
+                    'lon' => 90,
+                ])->id;
+            },
+            'organisation_id' => function () {
+                return factory(Organisation::class)->create(['name' => 'Test Name'])->id;
+            },
+        ]);
+
+        $event4 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 90,
+                    'lon' => 180,
+                ])->id;
+            },
+        ]);
+
+        $response = $this->json('POST', '/core/v1/search/events', [
+            'query' => 'Test Name',
+            'order' => 'relevance',
+            'location' => [
+                'lat' => 45,
+                'lon' => 90,
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment(['id' => $event2->id]);
+        $response->assertJsonFragment(['id' => $event3->id]);
+        $response->assertJsonMissing(['id' => $event1->id]);
+        $response->assertJsonMissing(['id' => $event4->id]);
+
+        $data = $this->getResponseContent($response)['data'];
+        $this->assertEquals(2, count($data));
+        $this->assertTrue(in_array($event2->id, [$data[0]['id'], $data[1]['id']]));
+        $this->assertTrue(in_array($event3->id, [$data[0]['id'], $data[1]['id']]));
+    }
+
+    /**
+     * @test
+     */
+    public function searchEventsOrderByRelevanceWithLocationReturnEventsLessThan1MileAway()
+    {
+        // Not relevant > 1 mile
+        $event1 = factory(OrganisationEvent::class)->create([
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 51.469954129107016,
+                    'lon' => -0.3973609967291171,
+                ])->id;
+            },
+        ]);
+
+        // Relevant < 1 mile
+        $event2 = factory(OrganisationEvent::class)->create([
+            'intro' => 'Thisisatest',
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 51.46813624630186,
+                    'lon' => -0.38543053111827796,
+                ])->id;
+            },
+        ]);
+
+        // Relevant < 1 mile
+        $event3 = factory(OrganisationEvent::class)->create([
+            'title' => 'Thisisatest',
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 51.46933926508632,
+                    'lon' => -0.3745729484111921,
+                ])->id;
+            },
+        ]);
+
+        // Relevant > 1 mile
+        $event4 = factory(OrganisationEvent::class)->create([
+            'title' => 'Thisisatest',
+            'is_virtual' => false,
+            'location_id' => function () {
+                return factory(Location::class)->create([
+                    'lat' => 51.46741441979822,
+                    'lon' => -0.40152378521657234,
+                ])->id;
+            },
+        ]);
+
+        $response = $this->json('POST', '/core/v1/search/events', [
+            'query' => 'Thisisatest',
+            'order' => 'relevance',
+            'distance' => 1,
+            'location' => [
+                'lat' => 51.46843366223185,
+                'lon' => -0.3674811879751439,
+            ],
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment(['id' => $event2->id]);
+        $response->assertJsonFragment(['id' => $event3->id]);
+        $response->assertJsonMissing(['id' => $event1->id]);
+        $response->assertJsonMissing(['id' => $event4->id]);
+
+        $data = $this->getResponseContent($response)['data'];
+        $this->assertEquals(2, count($data));
+        $this->assertEquals($event3->id, $data[0]['id']);
+        $this->assertEquals($event2->id, $data[1]['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function searchEventsMoreTaxonomiesInACategoryCollectionAreMoreRelevant()
+    {
+        // Create 3 taxonomies
+        $taxonomy1 = Taxonomy::category()->children()->create([
+            'name' => 'Red',
+            'order' => 1,
+            'depth' => 1,
+        ]);
+        $taxonomy2 = Taxonomy::category()->children()->create([
+            'name' => 'Blue',
+            'order' => 2,
+            'depth' => 1,
+        ]);
+        $taxonomy3 = Taxonomy::category()->children()->create([
+            'name' => 'Green',
+            'order' => 3,
+            'depth' => 1,
+        ]);
+
+        // Create a collection
+        $collection = Collection::create([
+            'type' => Collection::TYPE_ORGANISATION_EVENT,
+            'name' => 'Self Help',
+            'meta' => [],
+            'order' => 1,
+        ]);
+
+        // Link the taxonomies to the collection
+        $collection->collectionTaxonomies()->create(['taxonomy_id' => $taxonomy1->id]);
+        $collection->collectionTaxonomies()->create(['taxonomy_id' => $taxonomy2->id]);
+        $collection->collectionTaxonomies()->create(['taxonomy_id' => $taxonomy3->id]);
+
+        // Create 3 events
+        $event1 = factory(OrganisationEvent::class)->create([
+            'title' => 'Gold Co.',
+        ]);
+        $event2 = factory(OrganisationEvent::class)->create([
+            'title' => 'Silver Co.',
+        ]);
+        $event3 = factory(OrganisationEvent::class)->create([
+            'title' => 'Bronze Co.',
+        ]);
+
+        // Link the events to 1, 2 and 3 taxonomies respectively.
+        $event1->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy1->id]);
+        $event1->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy2->id]);
+        $event1->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy3->id]);
+        $event1->save(); // Update the Elasticsearch index.
+
+        $event2->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy1->id]);
+        $event2->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy2->id]);
+        $event2->save(); // Update the Elasticsearch index.
+
+        $event3->organisationEventTaxonomies()->create(['taxonomy_id' => $taxonomy1->id]);
+        $event3->save(); // Update the Elasticsearch index.
+
+        // Assert that when searching by collection, the events with more taxonomies are ranked higher.
+        $response = $this->json('POST', '/core/v1/search/events', [
+            'category' => $collection->name,
+        ]);
+
+        $response->assertStatus(Response::HTTP_OK);
+
+        $content = $this->getResponseContent($response)['data'];
+        $this->assertEquals($event1->id, $content[0]['id']);
+        $this->assertEquals($event2->id, $content[1]['id']);
+        $this->assertEquals($event3->id, $content[2]['id']);
     }
 
     /**

--- a/tests/Feature/SearchServiceTest.php
+++ b/tests/Feature/SearchServiceTest.php
@@ -434,7 +434,7 @@ class SearchServiceTest extends TestCase implements UsesElasticsearch
     {
         $service = factory(Service::class)->create();
         $serviceLocation = factory(ServiceLocation::class)->create(['service_id' => $service->id]);
-        DB::table('locations')->where('id', $serviceLocation->location->id)->update(['lat' => 19.9, 'lon' => 19.9]);
+        DB::table('locations')->where('id', $serviceLocation->location->id)->update(['lat' => 19.955, 'lon' => 19.955]);
         $service->save();
 
         $service2 = factory(Service::class)->create();
@@ -444,7 +444,7 @@ class SearchServiceTest extends TestCase implements UsesElasticsearch
 
         $service3 = factory(Service::class)->create();
         $serviceLocation3 = factory(ServiceLocation::class)->create(['service_id' => $service3->id]);
-        DB::table('locations')->where('id', $serviceLocation3->location->id)->update(['lat' => 20.15, 'lon' => 20.15]);
+        DB::table('locations')->where('id', $serviceLocation3->location->id)->update(['lat' => 20.05, 'lon' => 20.05]);
         $service3->save();
 
         $response = $this->json('POST', '/core/v1/search', [
@@ -458,6 +458,7 @@ class SearchServiceTest extends TestCase implements UsesElasticsearch
         $response->assertStatus(Response::HTTP_OK);
         $response->assertJsonFragment(['id' => $service2->id]);
         $hits = json_decode($response->getContent(), true)['data'];
+        $this->assertCount(3, $hits);
         $this->assertEquals($service2->id, $hits[0]['id']);
         $this->assertEquals($service->id, $hits[1]['id']);
         $this->assertEquals($service3->id, $hits[2]['id']);


### PR DESCRIPTION
### Summary

https://app.shortcut.com/ayup-digital-ltd/story/1946/event-filtering-post-code-should
https://app.shortcut.com/ayup-digital-ltd/story/1947/event-filtering-distance-should

- Events filtered by distance to location
- Distance can be passed but defaults to 5 miles
- Events ordered by distance in results when filtered by distance to location

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
