### PR TITLE
Hounslow sc 2081 bug events are viewable as an org admin from

### DIFF
--- a/app/Docs/Operations/OrganisationEvents/IndexOrganisationEventOperation.php
+++ b/app/Docs/Operations/OrganisationEvents/IndexOrganisationEventOperation.php
@@ -77,6 +77,11 @@ EOT
                         )
                     )
                     ->style(FilterParameter::STYLE_SIMPLE),
+                FilterParameter::create(null, 'has_permission')
+                    ->description('Does the organisation admin user have permission to view')
+                    ->schema(
+                        Schema::boolean()
+                    ),
                 IncludeParameter::create(null, ['organisation'])
             )
             ->responses(

--- a/app/Http/Controllers/Core/V1/OrganisationEventController.php
+++ b/app/Http/Controllers/Core/V1/OrganisationEventController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Core\V1;
 
 use App\Events\EndpointHit;
 use App\Http\Controllers\Controller;
+use App\Http\Filters\OrganisationEvent\HasPermissionFilter;
 use App\Http\Requests\OrganisationEvent\DestroyRequest;
 use App\Http\Requests\OrganisationEvent\IndexRequest;
 use App\Http\Requests\OrganisationEvent\ShowRequest;
@@ -57,6 +58,7 @@ class OrganisationEventController extends Controller
                 Filter::scope('has_wheelchair_access', 'hasWheelchairAccess'),
                 Filter::scope('has_induction_loop', 'hasInductionLoop'),
                 Filter::scope('collections', 'inCollections'),
+                Filter::custom('has_permission', HasPermissionFilter::class),
             ])
             ->allowedIncludes(['organisation'])
             ->allowedSorts([

--- a/app/Http/Filters/OrganisationEvent/HasPermissionFilter.php
+++ b/app/Http/Filters/OrganisationEvent/HasPermissionFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Filters\OrganisationEvent;
+
+use App\Models\Organisation;
+use App\Models\OrganisationEvent;
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\QueryBuilder\Filters\Filter;
+
+class HasPermissionFilter implements Filter
+{
+    /**
+     * @param \Illuminate\Database\Eloquent\Builder $query
+     * @param $value
+     * @param string $property
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function __invoke(Builder $query, $value, string $property): Builder
+    {
+        $organisationIds = [];
+        $user = request()->user('api');
+
+        if ($user && $user->isOrganisationAdmin()) {
+            $organisationIds = $user->organisations()
+                ->pluck(table(Organisation::class, 'id'))
+                ->toArray();
+        }
+
+        return $query->whereIn(table(OrganisationEvent::class, 'organisation_id'), $organisationIds);
+    }
+}

--- a/tests/Feature/OrganisationEventsTest.php
+++ b/tests/Feature/OrganisationEventsTest.php
@@ -382,6 +382,31 @@ class OrganisationEventsTest extends TestCase
     /**
      * @test
      */
+    public function getAllOrganisationEventsOnlyRelatedOrganisationsAsOrganisationAdmin200()
+    {
+        $organisation1 = factory(Organisation::class)->create();
+        $organisation2 = factory(Organisation::class)->create();
+        $user = factory(User::class)->create()->makeOrganisationAdmin($organisation1);
+
+        Passport::actingAs($user);
+
+        $organisationEvent1 = factory(OrganisationEvent::class)->create([
+            'organisation_id' => $organisation1->id,
+        ]);
+        $organisationEvent2 = factory(OrganisationEvent::class)->create([
+            'organisation_id' => $organisation2->id,
+        ]);
+
+        $response = $this->json('GET', "/core/v1/organisation-events?filter[has_permission]=true");
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJsonFragment(['id' => $organisationEvent1->id]);
+        $response->assertJsonMissing(['id' => $organisationEvent2->id]);
+    }
+
+    /**
+     * @test
+     */
     public function getAllOrganisationEventsCreatesAuditAsGuest200()
     {
         $this->fakeEvents();


### PR DESCRIPTION
### Summary

https://app.shortcut.com/ayup-digital-ltd/story/2081/bug-events-are-viewable-as-an-org-admin-from-another-organisation

- Created new HasPermissionFilter for OrganisationEvent
- Applied filter in controller

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
