### PR TITLE
Hounslow sc 2186 events added as an org admin don t get put

### DIFF
--- a/app/Docs/Operations/OrganisationEvents/StoreOrganisationEventOperation.php
+++ b/app/Docs/Operations/OrganisationEvents/StoreOrganisationEventOperation.php
@@ -2,15 +2,13 @@
 
 namespace App\Docs\Operations\OrganisationEvents;
 
-use App\Docs\Schemas\OrganisationEvent\OrganisationEventSchema;
+use App\Docs\Responses\UpdateRequestReceivedResponse;
 use App\Docs\Schemas\OrganisationEvent\StoreOrganisationEventSchema;
-use App\Docs\Schemas\ResourceSchema;
 use App\Docs\Tags\OrganisationEventsTag;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\BaseObject;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\MediaType;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\Operation;
 use GoldSpecDigital\ObjectOrientedOAS\Objects\RequestBody;
-use GoldSpecDigital\ObjectOrientedOAS\Objects\Response;
 
 class StoreOrganisationEventOperation extends Operation
 {
@@ -34,11 +32,7 @@ class StoreOrganisationEventOperation extends Operation
                     )
             )
             ->responses(
-                Response::created()->content(
-                    MediaType::json()->schema(
-                        ResourceSchema::create(null, OrganisationEventSchema::create())
-                    )
-                )
+                UpdateRequestReceivedResponse::create(null, StoreOrganisationEventSchema::create())
             );
     }
 }

--- a/app/Http/Controllers/Core/V1/OrganisationEventController.php
+++ b/app/Http/Controllers/Core/V1/OrganisationEventController.php
@@ -13,9 +13,9 @@ use App\Http\Requests\OrganisationEvent\UpdateRequest;
 use App\Http\Resources\OrganisationEventResource;
 use App\Http\Responses\ResourceDeleted;
 use App\Http\Responses\UpdateRequestReceived;
-use App\Models\File;
 use App\Models\OrganisationEvent;
-use App\Models\Taxonomy;
+use App\Models\UpdateRequest as UpdateRequestModel;
+use App\Services\DataPersistence\OrganisationEventPersistenceService;
 use DateTime;
 use Illuminate\Support\Facades\DB;
 use Spatie\QueryBuilder\Filter;
@@ -78,60 +78,25 @@ class OrganisationEventController extends Controller
      * Store a newly created resource in storage.
      *
      * @param \App\Http\Requests\OrganisationEvent\StoreRequest $request
+     * @param \App\Services\DataPersistence\OrganisationEventPersistenceService $persistenceService
      * @return \Illuminate\Http\Response
      */
-    public function store(StoreRequest $request)
+    public function store(StoreRequest $request, OrganisationEventPersistenceService $persistenceService)
     {
-        return DB::transaction(function () use ($request) {
-            // Create the organisation.
-            $organisationEvent = OrganisationEvent::create([
-                'title' => $request->title,
-                'start_date' => $request->start_date,
-                'end_date' => $request->end_date,
-                'start_time' => $request->start_time,
-                'end_time' => $request->end_time,
-                'intro' => $request->intro,
-                'description' => sanitize_markdown($request->description),
-                'is_free' => $request->is_free,
-                'fees_text' => $request->fees_text,
-                'fees_url' => $request->fees_url,
-                'organiser_name' => $request->organiser_name,
-                'organiser_phone' => $request->organiser_phone,
-                'organiser_email' => $request->organiser_email,
-                'organiser_url' => $request->organiser_url,
-                'booking_title' => $request->booking_title,
-                'booking_summary' => $request->booking_summary,
-                'booking_url' => $request->booking_url,
-                'booking_cta' => $request->booking_cta,
-                'homepage' => $request->homepage,
-                'is_virtual' => $request->is_virtual,
-                'location_id' => $request->location_id,
-                'image_file_id' => $request->image_file_id,
-                'organisation_id' => $request->organisation_id,
-            ]);
+        $entity = $persistenceService->store($request);
 
-            if ($request->filled('location_id')) {
-                $organisationEvent->load('location');
-            }
+        if ($entity instanceof UpdateRequestModel) {
+            event(EndpointHit::onCreate($request, "Created organisation event as update request [{$entity->id}]", $entity));
 
-            if ($request->filled('image_file_id')) {
-                /** @var \App\Models\File $file */
-                $file = File::findOrFail($request->image_file_id)->assigned();
+            return new UpdateRequestReceived($entity);
+        }
 
-                // Create resized version for common dimensions.
-                foreach (config('ck.cached_image_dimensions') as $maxDimension) {
-                    $file->resizedVersion($maxDimension);
-                }
-            }
+        // Ensure conditional fields are reset if needed.
+        $entity->resetConditionalFields();
 
-            // Create the category taxonomy records.
-            $taxonomies = Taxonomy::whereIn('id', $request->category_taxonomies)->get();
-            $organisationEvent->syncTaxonomyRelationships($taxonomies);
+        event(EndpointHit::onCreate($request, "Created organisation event [{$entity->id}]", $entity));
 
-            event(EndpointHit::onCreate($request, "Created organisation event [{$organisationEvent->id}]", $organisationEvent));
-
-            return new OrganisationEventResource($organisationEvent);
-        });
+        return new OrganisationEventResource($entity);
     }
 
     /**
@@ -160,59 +125,19 @@ class OrganisationEventController extends Controller
      *
      * @param \App\Http\Requests\OrganisationEvent\UpdateRequest $request
      * @param \App\Models\OrganisationEvent $organisationEvent
+     * @param \App\Services\DataPersistence\OrganisationEventPersistenceService $persistenceService
      * @return UpdateRequestReceived
      */
-    public function update(UpdateRequest $request, OrganisationEvent $organisationEvent)
-    {
-        return DB::transaction(function () use ($request, $organisationEvent) {
-            $data = array_filter_missing([
-                'title' => $request->missing('title'),
-                'start_date' => $request->missing('start_date'),
-                'end_date' => $request->missing('end_date'),
-                'start_time' => $request->missing('start_time'),
-                'end_time' => $request->missing('end_time'),
-                'intro' => $request->missing('intro'),
-                'description' => $request->missing('description', function ($description) {
-                    return sanitize_markdown($description);
-                }),
-                'is_free' => $request->missing('is_free'),
-                'fees_text' => $request->missing('fees_text'),
-                'fees_url' => $request->missing('fees_url'),
-                'organiser_name' => $request->missing('organiser_name'),
-                'organiser_phone' => $request->missing('organiser_phone'),
-                'organiser_email' => $request->missing('organiser_email'),
-                'organiser_url' => $request->missing('organiser_url'),
-                'booking_title' => $request->missing('booking_title'),
-                'booking_summary' => $request->missing('booking_summary'),
-                'booking_url' => $request->missing('booking_url'),
-                'booking_cta' => $request->missing('booking_cta'),
-                'homepage' => $request->missing('homepage'),
-                'is_virtual' => $request->missing('is_virtual'),
-                'location_id' => $request->missing('location_id'),
-                'image_file_id' => $request->missing('image_file_id'),
-                'category_taxonomies' => $request->missing('category_taxonomies'),
-            ]);
+    public function update(
+        UpdateRequest $request,
+        OrganisationEvent $organisationEvent,
+        OrganisationEventPersistenceService $persistenceService
+    ) {
+        $updateRequest = $persistenceService->update($request, $organisationEvent);
 
-            if ($request->filled('image_file_id')) {
-                /** @var \App\Models\File $file */
-                $file = File::findOrFail($request->image_file_id)->assigned();
+        event(EndpointHit::onUpdate($request, "Updated organisation event [{$organisationEvent->id}]", $organisationEvent));
 
-                // Create resized version for common dimensions.
-                foreach (config('ck.cached_image_dimensions') as $maxDimension) {
-                    $file->resizedVersion($maxDimension);
-                }
-            }
-
-            /** @var \App\Models\UpdateRequest $updateRequest */
-            $updateRequest = $organisationEvent->updateRequests()->create([
-                'user_id' => $request->user()->id,
-                'data' => $data,
-            ]);
-
-            event(EndpointHit::onUpdate($request, "Updated organisation event [{$organisationEvent->id}]", $organisationEvent));
-
-            return new UpdateRequestReceived($updateRequest);
-        });
+        return new UpdateRequestReceived($updateRequest);
     }
 
     /**

--- a/app/Http/Controllers/Core/V1/ServiceController.php
+++ b/app/Http/Controllers/Core/V1/ServiceController.php
@@ -83,6 +83,7 @@ class ServiceController extends Controller
      * Store a newly created resource in storage.
      *
      * @param \App\Http\Requests\Service\StoreRequest $request
+     * @param \App\Services\DataPersistence\ServicePersistenceService $persistenceService
      * @return \Illuminate\Http\Response
      */
     public function store(StoreRequest $request, ServicePersistenceService $persistenceService)
@@ -137,6 +138,7 @@ class ServiceController extends Controller
      *
      * @param \App\Http\Requests\Service\UpdateRequest $request
      * @param \App\Models\Service $service
+     * @param \App\Services\DataPersistence\ServicePersistenceService $persistenceService
      * @return UpdateRequestReceived
      */
     public function update(UpdateRequest $request, Service $service, ServicePersistenceService $persistenceService)

--- a/app/Http/Requests/OrganisationEvent/StoreRequest.php
+++ b/app/Http/Requests/OrganisationEvent/StoreRequest.php
@@ -8,6 +8,7 @@ use App\Models\Organisation;
 use App\Models\Role;
 use App\Models\Taxonomy;
 use App\Models\UserRole;
+use App\Rules\DateSanity;
 use App\Rules\FileIsMimeType;
 use App\Rules\FileIsPendingAssignment;
 use App\Rules\IsOrganisationAdmin;
@@ -47,10 +48,10 @@ class StoreRequest extends FormRequest
         return [
             'organisation_id' => ['required', 'exists:organisations,id', new IsOrganisationAdmin($this->user('api'))],
             'title' => ['required', 'string', 'min:1', 'max:255'],
-            'start_date' => ['required', 'date_format:Y-m-d', 'after:today'],
-            'end_date' => ['required', 'date_format:Y-m-d', 'after_or_equal:start_date'],
-            'start_time' => ['required', 'date_format:H:i:s'],
-            'end_time' => ['required', 'date_format:H:i:s', 'after_or_equal:start_time'],
+            'start_date' => ['required', 'date_format:Y-m-d', 'after:today', new DateSanity($this)],
+            'end_date' => ['required', 'date_format:Y-m-d', new DateSanity($this)],
+            'start_time' => ['required', 'date_format:H:i:s', new DateSanity($this)],
+            'end_time' => ['required', 'date_format:H:i:s', new DateSanity($this)],
             'intro' => ['required', 'string', 'min:1', 'max:300'],
             'description' => [
                 'required',

--- a/app/Http/Requests/OrganisationEvent/UpdateRequest.php
+++ b/app/Http/Requests/OrganisationEvent/UpdateRequest.php
@@ -8,6 +8,7 @@ use App\Models\Role;
 use App\Models\Taxonomy;
 use App\Models\UserRole;
 use App\Rules\CanUpdateCategoryTaxonomyRelationships;
+use App\Rules\DateSanity;
 use App\Rules\FileIsMimeType;
 use App\Rules\FileIsPendingAssignment;
 use App\Rules\MarkdownMaxLength;
@@ -46,10 +47,10 @@ class UpdateRequest extends FormRequest
     {
         return [
             'title' => ['string', 'min:1', 'max:255'],
-            'start_date' => ['date_format:Y-m-d', 'after:today'],
-            'end_date' => ['date_format:Y-m-d', 'after_or_equal:start_date'],
-            'start_time' => ['date_format:H:i:s'],
-            'end_time' => ['date_format:H:i:s', 'after_or_equal:start_time'],
+            'start_date' => ['date_format:Y-m-d', 'after:today', new DateSanity($this)],
+            'end_date' => ['date_format:Y-m-d', new DateSanity($this)],
+            'start_time' => ['date_format:H:i:s', new DateSanity($this)],
+            'end_time' => ['date_format:H:i:s', new DateSanity($this)],
             'intro' => ['string', 'min:1', 'max:300'],
             'description' => [
                 'string',

--- a/app/Rules/DateSanity.php
+++ b/app/Rules/DateSanity.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Rules;
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Validation\Rule;
+
+class DateSanity implements Rule
+{
+    /**
+     * @var Carbon\Carbon
+     */
+    protected $start;
+
+    /**
+     * @var Carbon\Carbon
+     */
+    protected $end;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param \Illuminate\Foundation\Http\FormRequest $request
+     */
+    public function __construct(\Illuminate\Foundation\Http\FormRequest $request)
+    {
+        if (isset($request->organisation_event)) {
+            $this->start = Carbon::parse($request->get('start_date', $request->organisation_event->start_date));
+            $this->end = Carbon::parse($request->get('end_date', $request->organisation_event->end_date));
+            $this->start->setTimeFromTimeString($request->get('start_time', $request->organisation_event->start_time));
+            $this->end->setTimeFromTimeString($request->get('end_time', $request->organisation_event->end_time));
+        } else {
+            $this->start = Carbon::parse($request->get('start_date', 'now'));
+            $this->end = Carbon::parse($request->get('end_date', 'now'));
+            $this->start->setTimeFromTimeString($request->get('start_time', '00:00:00'));
+            $this->end->setTimeFromTimeString($request->get('end_time', '00:00:00'));
+        }
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param string $attribute
+     * @param mixed $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        return $this->end->greaterThanOrEqualTo($this->start);
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The end date and time should be later than the start date and time';
+    }
+}

--- a/app/Services/DataPersistence/OrganisationEventPersistenceService.php
+++ b/app/Services/DataPersistence/OrganisationEventPersistenceService.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Services\DataPersistence;
+
+use App\Models\File;
+use App\Models\Model;
+use App\Models\OrganisationEvent;
+use App\Models\Taxonomy;
+use App\Models\UpdateRequest as UpdateRequestModel;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\DB;
+
+class OrganisationEventPersistenceService implements DataPersistenceService
+{
+    /**
+     * Store the model.
+     *
+     * @param \Illuminate\Foundation\Http\FormRequest $request
+     * @return \App\Models\UpdateRequest | \App\Models\OrganisationEvent
+     */
+    public function store(FormRequest $request)
+    {
+        return $request->user()->isGlobalAdmin()
+        ? $this->processAsNewEntity($request)
+        : $this->processAsUpdateRequest($request, null);
+    }
+
+    /**
+     * Update the model.
+     *
+     * @param \Illuminate\Foundation\Http\FormRequest $request
+     * @return \App\Models\UpdateRequest
+     */
+    public function update(FormRequest $request, Model $model)
+    {
+        return $this->processAsUpdateRequest($request, $model);
+    }
+
+    /**
+     * Process the requested changes and either update the model or store an update request.
+     *
+     * @param Illuminate\Foundation\Http\FormRequest $request
+     * @return \App\Models\OrganisationEvent
+     */
+    public function processAsNewEntity(FormRequest $request)
+    {
+        return DB::transaction(function () use ($request) {
+            // Create the organisation.
+            $organisationEvent = OrganisationEvent::create([
+                'title' => $request->title,
+                'start_date' => $request->start_date,
+                'end_date' => $request->end_date,
+                'start_time' => $request->start_time,
+                'end_time' => $request->end_time,
+                'intro' => $request->intro,
+                'description' => sanitize_markdown($request->description),
+                'is_free' => $request->is_free,
+                'fees_text' => $request->fees_text,
+                'fees_url' => $request->fees_url,
+                'organiser_name' => $request->organiser_name,
+                'organiser_phone' => $request->organiser_phone,
+                'organiser_email' => $request->organiser_email,
+                'organiser_url' => $request->organiser_url,
+                'booking_title' => $request->booking_title,
+                'booking_summary' => $request->booking_summary,
+                'booking_url' => $request->booking_url,
+                'booking_cta' => $request->booking_cta,
+                'homepage' => $request->homepage,
+                'is_virtual' => $request->is_virtual,
+                'location_id' => $request->location_id,
+                'image_file_id' => $request->image_file_id,
+                'organisation_id' => $request->organisation_id,
+            ]);
+
+            if ($request->filled('location_id')) {
+                $organisationEvent->load('location');
+            }
+
+            if ($request->filled('image_file_id')) {
+                /** @var \App\Models\File $file */
+                $file = File::findOrFail($request->image_file_id)->assigned();
+
+                // Create resized version for common dimensions.
+                foreach (config('ck.cached_image_dimensions') as $maxDimension) {
+                    $file->resizedVersion($maxDimension);
+                }
+            }
+
+            // Create the category taxonomy records.
+            $taxonomies = Taxonomy::whereIn('id', $request->category_taxonomies)->get();
+            $organisationEvent->syncTaxonomyRelationships($taxonomies);
+
+            return $organisationEvent;
+        });
+    }
+
+    /**
+     * Process the requested changes and either update the model or store an update request.
+     *
+     * @param Illuminate\Foundation\Http\FormRequest $request
+     * @param \App\Models\OrganisationEvent $event
+     * @return \App\Models\UpdateRequest
+     */
+    public function processAsUpdateRequest(FormRequest $request, ?OrganisationEvent $event)
+    {
+        return DB::transaction(function () use ($request, $event) {
+            $data = array_filter_missing([
+                'title' => $request->missing('title'),
+                'start_date' => $request->missing('start_date'),
+                'end_date' => $request->missing('end_date'),
+                'start_time' => $request->missing('start_time'),
+                'end_time' => $request->missing('end_time'),
+                'intro' => $request->missing('intro'),
+                'description' => $request->missing('description', function ($description) {
+                    return sanitize_markdown($description);
+                }),
+                'is_free' => $request->missing('is_free'),
+                'fees_text' => $request->missing('fees_text'),
+                'fees_url' => $request->missing('fees_url'),
+                'organiser_name' => $request->missing('organiser_name'),
+                'organiser_phone' => $request->missing('organiser_phone'),
+                'organiser_email' => $request->missing('organiser_email'),
+                'organiser_url' => $request->missing('organiser_url'),
+                'booking_title' => $request->missing('booking_title'),
+                'booking_summary' => $request->missing('booking_summary'),
+                'booking_url' => $request->missing('booking_url'),
+                'booking_cta' => $request->missing('booking_cta'),
+                'homepage' => $request->missing('homepage'),
+                'is_virtual' => $request->missing('is_virtual'),
+                'organisation_id' => $request->missing('organisation_id'),
+                'location_id' => $request->missing('location_id'),
+                'image_file_id' => $request->missing('image_file_id'),
+                'category_taxonomies' => $request->missing('category_taxonomies'),
+            ]);
+
+            if ($request->filled('image_file_id')) {
+                /** @var \App\Models\File $file */
+                $file = File::findOrFail($request->image_file_id)->assigned();
+
+                // Create resized version for common dimensions.
+                foreach (config('ck.cached_image_dimensions') as $maxDimension) {
+                    $file->resizedVersion($maxDimension);
+                }
+            }
+
+            /** @var \App\Models\UpdateRequest $updateRequest */
+            $updateRequest = new UpdateRequestModel([
+                'updateable_type' => $event ? UpdateRequestModel::EXISTING_TYPE_ORGANISATION_EVENT : UpdateRequestModel::NEW_TYPE_ORGANISATION_EVENT,
+                'updateable_id' => $event->id ?? null,
+                'user_id' => $request->user()->id,
+                'data' => $data,
+            ]);
+
+            // Only persist to the database if the user did not request a preview.
+            if ($updateRequest->updateable_type === UpdateRequestModel::EXISTING_TYPE_ORGANISATION_EVENT) {
+                // Preview currently only available for update operations
+                if (!$request->isPreview()) {
+                    $updateRequest->save();
+                }
+            } else {
+                $updateRequest->save();
+            }
+
+            return $updateRequest;
+        });
+    }
+}

--- a/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\UpdateRequest;
+
+use App\Http\Requests\OrganisationEvent\StoreRequest;
+use App\Models\File;
+use App\Models\OrganisationEvent;
+use App\Models\Taxonomy;
+use App\Models\UpdateRequest;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Validator as ValidatorFacade;
+
+class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
+{
+    /**
+     * Check if the update request is valid.
+     *
+     * @param \App\Models\UpdateRequest $updateRequest
+     * @return \Illuminate\Contracts\Validation\Validator
+     */
+    public function validateUpdateRequest(UpdateRequest $updateRequest): Validator
+    {
+        $user = Auth::user();
+        $rules = (new StoreRequest())
+            ->merge($updateRequest->data)
+            ->setUserResolver(function () use ($updateRequest) {
+                return $updateRequest->user;
+            })
+            ->rules();
+
+        return ValidatorFacade::make($updateRequest->data, $rules);
+    }
+
+    /**
+     * Apply the update request.
+     *
+     * @param \App\Models\UpdateRequest $updateRequest
+     * @return \App\Models\UpdateRequest
+     */
+    public function applyUpdateRequest(UpdateRequest $updateRequest): UpdateRequest
+    {
+        $data = collect($updateRequest->data);
+
+        $organisationEvent = OrganisationEvent::create([
+            'title' => $data->get('title'),
+            'start_date' => $data->get('start_date'),
+            'end_date' => $data->get('end_date'),
+            'start_time' => $data->get('start_time'),
+            'end_time' => $data->get('end_time'),
+            'intro' => $data->get('intro'),
+            'description' => sanitize_markdown(
+                $data->get('description')
+            ),
+            'is_free' => $data->get('is_free'),
+            'fees_text' => $data->get('fees_text'),
+            'fees_url' => $data->get('fees_url'),
+            'organiser_name' => $data->get('organiser_name'),
+            'organiser_phone' => $data->get('organiser_phone'),
+            'organiser_email' => $data->get('organiser_email'),
+            'organiser_url' => $data->get('organiser_url'),
+            'booking_title' => $data->get('booking_title'),
+            'booking_summary' => $data->get('booking_summary'),
+            'booking_url' => $data->get('booking_url'),
+            'booking_cta' => $data->get('booking_cta'),
+            'homepage' => $data->get('homepage'),
+            'is_virtual' => $data->get('is_virtual'),
+            'organisation_id' => $data->get('organisation_id'),
+            'location_id' => $data->get('location_id'),
+            'image_file_id' => $data->get('image_file_id'),
+            // This must always be updated regardless of the fields changed.
+            // 'last_modified_at' => Carbon::now(),
+        ]);
+
+        if ($updateRequest->filled('location_id')) {
+            $organisationEvent->load('location');
+        }
+
+        if ($updateRequest->filled('image_file_id')) {
+            /** @var \App\Models\File $file */
+            $file = File::findOrFail($updateRequest->image_file_id)->assigned();
+
+            // Create resized version for common dimensions.
+            foreach (config('ck.cached_image_dimensions') as $maxDimension) {
+                $file->resizedVersion($maxDimension);
+            }
+        }
+
+        // Create the category taxonomy records.
+        $taxonomies = Taxonomy::whereIn('id', $updateRequest->category_taxonomies)->get();
+        $organisationEvent->syncTaxonomyRelationships($taxonomies);
+
+        // Ensure conditional fields are reset if needed.
+        $organisationEvent->resetConditionalFields();
+
+        return $updateRequest;
+    }
+
+    /**
+     * Custom logic for returning the data. Useful when wanting to transform
+     * or modify the data before returning it, e.g. removing passwords.
+     *
+     * @param array $data
+     * @return array
+     */
+    public function getData(array $data): array
+    {
+        Arr::forget($data, ['user.password']);
+
+        return $data;
+    }
+}

--- a/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewOrganisationEventCreatedByOrgAdmin.php
@@ -73,13 +73,9 @@ class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
             // 'last_modified_at' => Carbon::now(),
         ]);
 
-        if ($updateRequest->filled('location_id')) {
-            $organisationEvent->load('location');
-        }
-
-        if ($updateRequest->filled('image_file_id')) {
+        if ($data->has('image_file_id') && !empty($data->get('image_file_id'))) {
             /** @var \App\Models\File $file */
-            $file = File::findOrFail($updateRequest->image_file_id)->assigned();
+            $file = File::findOrFail($data->get('image_file_id'))->assigned();
 
             // Create resized version for common dimensions.
             foreach (config('ck.cached_image_dimensions') as $maxDimension) {
@@ -87,9 +83,11 @@ class NewOrganisationEventCreatedByOrgAdmin implements AppliesUpdateRequests
             }
         }
 
-        // Create the category taxonomy records.
-        $taxonomies = Taxonomy::whereIn('id', $updateRequest->category_taxonomies)->get();
-        $organisationEvent->syncTaxonomyRelationships($taxonomies);
+        if ($data->has('category_taxonomies') && !empty($data->get('category_taxonomies'))) {
+            // Create the category taxonomy records.
+            $taxonomies = Taxonomy::whereIn('id', $data->get('category_taxonomies'))->get();
+            $organisationEvent->syncTaxonomyRelationships($taxonomies);
+        }
 
         // Ensure conditional fields are reset if needed.
         $organisationEvent->resetConditionalFields();

--- a/app/UpdateRequest/NewServiceCreatedByOrgAdmin.php
+++ b/app/UpdateRequest/NewServiceCreatedByOrgAdmin.php
@@ -75,9 +75,9 @@ class NewServiceCreatedByOrgAdmin implements AppliesUpdateRequests
 
         $service = Service::create($insert);
 
-        if (array_key_exists('useful_infos', $data)) {
+        if ($data->has('useful_infos')) {
             $service->usefulInfos()->delete();
-            foreach ($data['useful_infos'] as $usefulInfo) {
+            foreach ($data->get('useful_infos') as $usefulInfo) {
                 $service->usefulInfos()->create([
                     'title' => $usefulInfo['title'],
                     'description' => sanitize_markdown($usefulInfo['description']),
@@ -87,9 +87,9 @@ class NewServiceCreatedByOrgAdmin implements AppliesUpdateRequests
         }
 
         // Update the offering records.
-        if (array_key_exists('offerings', $data)) {
+        if ($data->has('offerings')) {
             $service->offerings()->delete();
-            foreach ($data['offerings'] as $offering) {
+            foreach ($data->get('offerings') as $offering) {
                 $service->offerings()->create([
                     'offering' => $offering['offering'],
                     'order' => $offering['order'],
@@ -98,9 +98,9 @@ class NewServiceCreatedByOrgAdmin implements AppliesUpdateRequests
         }
 
         // Update the gallery item records.
-        if (array_key_exists('gallery_items', $updateRequest->data)) {
+        if ($data->has('gallery_items')) {
             $service->serviceGalleryItems()->delete();
-            foreach ($data['gallery_items'] as $galleryItem) {
+            foreach ($data->get('gallery_items') as $galleryItem) {
                 $service->serviceGalleryItems()->create([
                     'file_id' => $galleryItem['file_id'],
                 ]);
@@ -108,9 +108,9 @@ class NewServiceCreatedByOrgAdmin implements AppliesUpdateRequests
         }
 
         // Update the category taxonomy records.
-        if (array_key_exists('category_taxonomies', $data)) {
+        if ($data->has('category_taxonomies')) {
             $taxonomies = Taxonomy::whereIn('id', $data['category_taxonomies'])->get();
-            $service->syncServiceTaxonomies($taxonomies);
+            $service->syncTaxonomyRelationships($taxonomies);
         }
 
         // Ensure conditional fields are reset if needed.


### PR DESCRIPTION
### Summary

https://app.shortcut.com/ayup-digital-ltd/story/2186/events-added-as-an-org-admin-don-t-get-put-into-the-update-request-queue

- Created update request cycle for organisation events when created by org admin

### Development checklist

- [x] Changes have been made to the API?
  - [x] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [x] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
